### PR TITLE
Updated Hashable protocol compliance in UInt4 to Swift Version 4.0+

### DIFF
--- a/UInt4/UInt4+Hashable.swift
+++ b/UInt4/UInt4+Hashable.swift
@@ -27,7 +27,13 @@
 import Foundation
 
 extension UInt4: Hashable {
+    @available(swift, deprecated: 4.0, message: "Deprecated in Swift 4.0 - Use hash(into:) instead")
     public var hashValue: Int {
         return internalValue.hashValue
+    }
+
+    @available(swift 4.0)
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(internalValue)
     }
 }

--- a/UInt4Tests/UInt4+HashableTests.swift
+++ b/UInt4Tests/UInt4+HashableTests.swift
@@ -28,13 +28,11 @@ import XCTest
 @testable import UInt4
 
 class UInt4_HashableTests: XCTestCase {
-    
+
     func testHashEqualToInternalValueHash() {
         let x:UInt4 = 8
         let y:Int = 8
 
         XCTAssertEqual(x.hashValue, y.hashValue)
-    
     }
-    
 }


### PR DESCRIPTION
# Description

The Pull Request updates the `UInt4` `Hashable` protocol compliance to Swift Version 4.0+.

- Marked `hashValue` as deprecated
- Implemented `hash(into:)` protocol method
- Eliminating the compiler warning: `(30, 16) 'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'UInt4' to 'Hashable' by implementing 'hash(into:)' instead`