### PR TITLE
Conform to `Hashable`

### DIFF
--- a/UInt4/UInt4+Hashable.swift
+++ b/UInt4/UInt4+Hashable.swift
@@ -27,7 +27,7 @@
 import Foundation
 
 extension UInt4: Hashable {
-    public var hashValue: Int {
-        return internalValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(internalValue)
     }
 }


### PR DESCRIPTION
This is to get rid of a build warning when using `hashValue()`